### PR TITLE
Fix for Yosemite (10.10)

### DIFF
--- a/targets/ios/build-binary
+++ b/targets/ios/build-binary
@@ -106,7 +106,7 @@ assertfile $tmpappdir
 
 echo " => verifying application.."
 osxver=`sw_vers -productVersion`
-if [ `echo "10.9.5\n$osxver" | sort -g | head -1` == "10.9.5" ]; then
+if [ `echo "10.9.5\n$osxver" | sed 's/^10\.//' | sort -g | head -1` == "9.5" ]; then
   checkfail=`codesign --verify --no-strict $tmpappdir 2>&1`
 else
   checkfail=`codesign --verify $tmpappdir 2>&1`


### PR DESCRIPTION
10.10 is treated as less than 10.9.5:

``` sh
% printf '10.10\n10.9.5\n10.8\n' | sort -g
10.10
10.8
10.9.5
% printf '10.10\n10.9.5\n10.8\n' | sed 's/^10\.//' | sort -g
8
9.5
10
```

Of course, this fix will only work until OS X goes from 10.10 to 11.0
