### PR TITLE
Added --without-libssh2 as well as earlier RTMP and IDN modifications…

### DIFF
--- a/libraries/libcurl/make.sh
+++ b/libraries/libcurl/make.sh
@@ -10,7 +10,7 @@ if [ ! $SYS_PLATFORM = $SYS_HOSTPLATFORM ]; then
   EXTRACONF=--host=$SYS_ARCH
 fi
 
-package_configure $EXTRACONF --disable-ldap --disable-shared --enable-static --without-librtmp --without-libidn
+package_configure $EXTRACONF --disable-ldap --disable-shared --enable-static --without-librtmp --without-libidn --without-libssh2
 
 package_make
 asserterror $? "compilation failed"


### PR DESCRIPTION
Having removed libraries RTMP and IDN from the curl build, it was also necessary to remove SSH2 as well. This now means it builds out of the box on Yosemite 10.10.5.
