### PR TITLE
Add Shadchen pattern matcher to modules, improve looping sound support by enabling the ability to stop sounds

### DIFF
--- a/loaders/android/bootstrap.c.in
+++ b/loaders/android/bootstrap.c.in
@@ -139,6 +139,7 @@ void SoundPoolInit()
            "()L@SYS_ORGTLD@/@SYS_ORGSLD@/@SYS_LOCASEAPPNAME@/AudioHelper;");
         s_load = (*env)->GetMethodID(env,soundpool_class, "LoadSound", "(Ljava/lang/String;I)I");
         s_play = (*env)->GetMethodID(env,soundpool_class, "PlaySound", "(IFFIIF)I");
+	s_stop = (*env)->GetMethodID(env,soundpool_class, "StopSound", "(I)I");
         s_unload = (*env)->GetMethodID(env,soundpool_class, "UnloadSound", "(I)Z");
         s_setvolume = (*env)->GetMethodID(env,soundpool_class, "SetVolume", "(F)Z");
         s_getvolume = (*env)->GetMethodID(env,soundpool_class, "GetVolume", "()F");
@@ -173,6 +174,16 @@ int SoundPoolPlaySound(int SoundID, float LeftVolume, float RightVolume, int Pri
   JNIEnv *env = GetJNIEnv();
   if (env&&s_globalThiz) {
     return (*env)->CallIntMethod(env,s_globalThiz, s_play, SoundID, LeftVolume, RightVolume, Priority, Loop, Rate);
+  } else {
+    return -1;
+  }
+}
+
+int SoundPoolStopSound(int SoundID)
+{
+  JNIEnv *env = GetJNIEnv();
+  if (env&&s_globalThiz) {
+    return (*env)->CallIntMethod(env,s_globalThiz, s_stop);
   } else {
     return -1;
   }

--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -253,6 +253,11 @@ class AudioHelper {
 	    }
 	    this.player.start();
 	}
+	public void stop(){
+	    this.playState = STOPPED;
+	    this.player.seekTo(0);
+	    this.payer.stop();
+	}
 	public void pause(){
 	    if(this.playState == PlayState.PLAYING || this.playState == PlayState.LOOPING){
 		this.player.pause();
@@ -326,6 +331,13 @@ class AudioHelper {
       MediaPlayerHelper localMediaPlayer = mediaPlayers.get(SoundID-1);
       if(localMediaPlayer!=null){
 	  localMediaPlayer.start(rv, lv, loop);
+      }
+      return SoundID;
+  }
+  public int StopSound(int SoundID) {
+      MediaPlayerHelper localMediaPlayer = mediaPlayers.get(SoundID-1);
+      if(localMediaPlayer!=null){
+	  localMediaPlayer.stop();
       }
       return SoundID;
   }

--- a/modules/audio/audiofile.scm
+++ b/modules/audio/audiofile.scm
@@ -292,6 +292,19 @@ void audiofile_stop()
 #endif
 }
 
+void audiofile_stop_specific(int id)
+{
+#ifdef USE_PORTAUDIO
+  portaudio_stop(id);
+#endif
+#ifdef USE_IOS_REALTIME
+  iphone_realtime_stop(id);
+#endif
+#ifdef USE_ANDROID_NATIVE
+  SoundPoolStopSound(id);
+#endif
+}
+
 void audiofile_play(int id)
 {
 #ifdef USE_ANDROID_NATIVE

--- a/modules/audio/audiofile.scm
+++ b/modules/audio/audiofile.scm
@@ -133,6 +133,17 @@ static void iphone_realtime_play(int id)
   audiofile_select(id);
 }
 
+static void iphone_realtime_loop(int id)
+{
+  audiofile_select(id);
+  audiofiles[id-1].playing = LOOPING;
+}
+
+static void iphone_realtime_stop(int id){
+  audiofile_select(id);
+  audiofiles[id-1].playing = NOT_PLAYING;
+}
+
 #endif
 
 // %%%%%%%%%%%%%%%%%%%%%%
@@ -227,6 +238,14 @@ static void portaudio_loop(int id)
   audiofile_select(id);
   audiofiles[id-1].playing = LOOPING;
 }
+
+static void portaudio_stop(int id)
+{
+  audiofile_select(id);
+  audiofiles[id-1].playing = NOT_PLAYING;
+}
+
+
 
 
 #endif
@@ -334,7 +353,7 @@ void audiofile_loop(int id)
  SoundPoolPlaySound(id,1.0,1.0,0.0,-1,1.0);
 #endif
 #ifdef USE_IOS_REALTIME
- iphone_realtime_play(id);
+ iphone_realtime_loop(id);
 #endif
 #ifdef USE_APPLE_NATIVE
   SystemSoundID sid=(SystemSoundID)id;
@@ -418,7 +437,13 @@ end-of-c-declare
   ))
 
 (define audiofile-start (c-lambda () int "audiofile_start"))
-(define audiofile-stop (c-lambda () void "audiofile_stop"))
+(define audiofile-stop-all (c-lambda () void "audiofile_stop"))
+(define audiofile-stop-one (c-lambda (int) void "audiofile_stop_specific"))
+(define (audiofile-stop #!optional (id #f))
+  (if (eq? id #f)
+      (audiofile-stop-all)
+      (audiofile-stop-one id)))
+
 
 (define audiofile-getvolume (c-lambda () float "audiofile_getvolume"))
 ;;eof

--- a/modules/scran/global-macros.scm
+++ b/modules/scran/global-macros.scm
@@ -1,0 +1,12 @@
+;;; Gambit-c requires that macro-code be `included` directly into
+;;; source code that uses it.  Hence, we separate the macro code from
+;;; the main body of the scran so that the main body of the code
+;;; doesn't need to be endlessly recompiled.
+
+(define-macro (define-component name args #!rest body)
+  `(define ,name (component! (lambda ,args ,@body) (symbol->string ',name))))
+
+(define-macro (define-system name args)
+  `(define ,name (system! ,@args)))
+
+

--- a/modules/scran/scran-macros.scm
+++ b/modules/scran/scran-macros.scm
@@ -1,7 +1,0 @@
-;;; Gambit-c requires that macro-code be `included` directly into
-;;; source code that uses it.  Hence, we separate the macro code from
-;;; the main body of the scran so that the main body of the code
-;;; doesn't need to be endlessly recompiled.
-
-(define-macro (define-component name args #!rest body)
-  `(define ,name (component! (lambda ,args ,@body) (symbol->string ',name))))

--- a/modules/shadchen/LICENSE
+++ b/modules/shadchen/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/modules/shadchen/README.md
+++ b/modules/shadchen/README.md
@@ -1,0 +1,122 @@
+Shadchen
+--------
+
+Now for Gambit-c/Lambdanative!
+
+Shadchen is a simple, extensible pattern matcher now for Gambit-c, Common Lisp and Emacs Lisp.  A very similar matcher is built into Gazelle, a Lisp for Javascript.  Once you get used to programming with a pattern matcher it is hard to go back.
+
+Shadchen provides basic matching support for Scheme data structures and is _extensible_, in that the application programmer can declare and use custom patterns to express arbitrary matches.
+
+Example Usage
+-------------
+
+    (match 'x
+     (('x 'matched-literal-x)))      
+    
+    (define (reverse3 seq)       
+     (match seq
+      ((list a b c) (list c b a))
+      ((vector a b c) (list c b a))))      
+
+    ;; or equivalently:        
+
+    (define (reverse3 seq)       
+     (match seq 		 
+      ((or (vector a b c) (list a b c)) (list c b a)))) 
+
+
+Documentation
+-------------
+
+### match 
+
+    (match <expr> ((<pattern1> <body1> ...) ...))
+
+match evaluates expression `<expr>` and then attempts to match that value against each of the patterns `<pattern1>` through `<patternN>`.  When a matching pattern is encountered, the `<bodyK>` associated with that pattern is evaluated and the value of the last expression is returned.  No further matches are attempted, and no other bodies execute.
+
+If no patterns match, an error is thrown indicating the value and forms which failed to produce a match.
+
+### define-pattern
+
+    (define-pattern (<name> <arg1> ...) <body1> ...)
+
+Define a new pattern.  User defined patterns must expand to a pattern expression defined by other user defined patterns or primitive types.  The result must, therefore, be an s-expression and so patterns are similar to macro definitions.  
+
+For instance, here is the pattern definition for matching against cons cells:
+
+    (define-pattern (pair cr cd)
+      `(and (? pair?)
+            (call (lambda (pair)
+                    (list (car pair) (cdr pair)))
+                  (list ,cr ,cd))))
+
+
+The result of evaluating the body of this expression is a new pattern expression.
+
+### Built-in patterns
+
+`<symbol>` 
+
+A symbol matches any expression and binds the value to that symbol.
+
+eg: `(match 10 ((x x))) -> 10`.
+
+`<string-literal>`
+
+A string literal matches exactly that string and binds no values.
+
+`<numeric-literal>` 
+
+A literal number matches anything to which it is `=`
+
+`<keyword-literal>`
+
+Matches exactly that keyword. 
+
+`(list sub-pattern1 <and-N-more-sub-patterns>>)`
+
+Matches a list of length `N` if each sub-pattern matches the associated element of the list.  Binds those bindings implied by all sub-patterns.
+
+`(list sub-pattern1 <and-N-more-sub-patterns> sub-pattern-N ...)`
+
+Matches a list with at least N-1 elements, and matches <sub-pattern-N> against the umatched tail of the list.  Can match if the tail is empty.  Binds exactly the bindings implied by the sub-patterns.
+
+`(vector <patterns...>)`
+
+Exactly the same as `list` matching.
+
+`(? predicate <pattern1> ...)`
+
+Matches if `predicate` is true on the value and all patterns also match.  Binds the bindings of the patterns.
+
+`(call function <pattern1> ...)`
+
+Transforms the value to be matched via function and then matches the patterns.  Binds the implied bindings of the sub-patterns. 
+
+`(call* function <pattern1> ...)`
+
+As in `call` except that if function returns `*match-fail*` the match fails.  This allows you to drop out of the pattern matcher and place arbitrary modification and matching.  A common pattern is to use `call*` to both detect match failures and transform a value in preparation for subsequent matches.  For instance, we could write a match against `cons` cells like this:
+
+   (define-pattern (cons-cell car-pattern cdr-pattern)
+    `(call* (lambda (object)
+             (if (pair? object) (list (car object) (cdr object))
+                 *match-fail*))
+            (list ,car-pattern ,cdr-pattern)))
+
+`(or sub-patterns ...)`
+
+Matches any of the `sub-patterns`.  Given the nature of pattern matching, each sub-pattern must result in the same set of bound values.  This is checked statically, and it is a macro-expansion time error to try to `or` with disjoint patterns.
+
+`(and sub-patterns)` 
+
+Matches ALL of the `sub-patterns` or fails.  Sub patterns do not need to bind the same symbols (and in general will not).  
+
+`(let bindings ...)`
+
+Always succeeds and binds the implied values/name pairs in bindings, like a let expression.
+
+eg:
+    
+    `(match (some-value) ((let (x 10) (y 11)) (list x y)))`
+
+returns `(10 11)`, regardless of what `(some-value)` evaluates to.  A combination of `or` and `let` can allow you to provide default bindings in the case of what would otherwise be a failed match.

--- a/modules/shadchen/global-macros.scm
+++ b/modules/shadchen/global-macros.scm
@@ -1,0 +1,246 @@
+(define *match-fail* (string->symbol "match-fail-e1aa3b7e7ce9731266013c178de842b5"))
+
+;; Evaluate expressions as though in a `begin` at macro-expansion time
+;; and at run time.
+(define-macro (at-expand-time-and-runtime #!rest exprs)
+   (eval `(begin ,@exprs))
+   `(begin ,@exprs))
+
+;; Evaluate expressions as thought in a `begin` at macro-expansion time.
+(define-macro (at-expand-time #!rest exprs)
+  (eval `(begin ,@exprs))
+  `(begin #f))
+
+(at-expand-time-and-runtime
+
+ ;; Contains custom pattern matchers. 
+ (define *custom-matchers* (make-table test: eq?))
+
+ ;; Utility to add a pattern matcher expander. 
+ (define (add-pattern-matcher name fun)
+   (table-set! *custom-matchers* name fun))
+
+ ;; Given a symbol/name and arguments, return a new pattern matching
+ ;; expression by calling the correct expander.
+ (define (expand-custom-matcher name #!rest args)
+   (apply (table-ref *custom-matchers* name) args))
+
+ ;; Returns #t when SYMBOL denotes a custom pattern matcher.
+ (define (custom-pattern? symbol)
+   (if (table-ref *custom-matchers* symbol) #t #f)))
+
+;; Add a custom pattern matcher.  Patterns are similar to macros in
+;; that they take arguments and must return a pattern expression.
+(define-macro (define-pattern name-and-args #!rest body)
+  `(at-expand-time-and-runtime
+	(add-pattern-matcher ',(car name-and-args)
+						 (lambda ,(cdr name-and-args) ,@body))))
+
+(at-expand-time-and-runtime 
+
+ ;; Given the sub-patterns from a list pattern matching expression,
+ ;; return all the implied bound symbols.
+ (define (list-pattern-bound-symbols sub-patterns #!optional (acc '()))
+   (cond ((eq? sub-patterns '()) acc)
+		 ((and (= 2 (length sub-patterns))
+			   (eq? '... (cadr sub-patterns)))
+		  (append (pattern-bound-symbols (car sub-patterns)) acc))
+		 (else (list-pattern-bound-symbols (cdr sub-patterns) (append acc (pattern-bound-symbols (car sub-patterns)))))))
+
+ ;; Given any pattern expression, return a list of the symbols it binds on success.
+ (define (pattern-bound-symbols pattern) 
+   (define (symbol< s1 s2)
+	 (string<? (symbol->string s1)
+			   (symbol->string s2)))
+   (define (pattern-bound-symbols* pattern #!optional (acc (list)))
+	 (cond
+	  ((eq? pattern #t) acc)
+	  ((eq? pattern #f) acc)
+	  ((symbol? pattern) (cons pattern acc))
+	  ((or (number? pattern) (keyword? pattern) (string? pattern)) acc)
+	  ((list? pattern)
+	   (let ((sigil (car pattern))
+			 (pattern-body (cdr pattern)))
+		 (cond 
+		  ((eq? sigil 'let)
+		   (append acc (map car pattern-body)))
+		  ((eq? sigil 'quote) acc)
+		  ((eq? sigil 'list)
+		   (append acc (list-pattern-bound-symbols pattern-body)))
+		  ((eq? sigil 'and)
+		   (apply append acc (map pattern-bound-symbols* pattern-body)))
+		  ((eq? sigil 'or)
+		   (pattern-bound-symbols* (car pattern-body) acc))
+		  ((or 
+			(eq? sigil 'call)
+			(eq? sigil 'call*)
+			(eq? sigil '?))
+		   (let ((predicate-expr (car pattern-body))
+				 (patterns (cdr pattern-body)))
+			 (pattern-bound-symbols* `(and ,@patterns) acc)))
+		  (else 
+		   (if (custom-pattern? sigil) 
+			   (pattern-bound-symbols* (apply expand-custom-matcher sigil pattern-body) acc)
+			   (error (string-append " Unrecognized pattern name: " (symbol->string sigil))))))))))
+   (pattern-bound-symbols* pattern))
+
+ ;; Return #t when S1 and S2, lists of symbols, are set-equivalent.
+ (define (sets-equal? s1 s2 #!key (test eq?))
+   (define (list->truth-table l)
+	 (pretty-print (list "list->truth-table " l)) (newline)
+	 (let ((tbl (make-table test: test)))
+	   (let sets-equal-loop ((rest l))
+		 (if (eq? '() rest)
+			 tbl
+			 (begin (table-set! tbl (car rest) #t)
+					(sets-equal-loop (cdr rest)))))))
+   (define (all-keys-in-table? keys tbl)	 
+	 (if (eq? '() keys) #t
+		 (let ((key (car keys))
+			   (rest (cdr keys)))
+		   (if (table-ref tbl key #f)
+			   (all-keys-in-table? rest tbl)
+			   #f))))
+   (and (all-keys-in-table? s1 (list->truth-table s2))
+		(all-keys-in-table? s2 (list->truth-table s1))))
+
+ ;; Return #t when all of the sets, lists of symbols, in SETS are
+ ;; set-equivalent.
+ (define (all-sets-equal? #!rest sets) 
+   (define (all-sets-equal?* set1 set2 #!rest sets)
+	 (let ((these-two (sets-equal? set1 set2))) 
+	   (if (eq? '() sets) these-two		
+		   (if these-two (apply all-sets-equal?* set1 sets) #f))))
+   (if (> (length sets) 1) (apply all-sets-equal?* sets)
+	   #t)))
+
+;; Given an expression, a pattern (FORM) and a body, either match the
+;; pattern FORM and evaluate body with the implied binding or return
+;; the special value *match-fail*.
+(define-macro (match1-or-fail expr form #!rest body)  
+  (cond 
+   ((eq? form #t) `(if (eq? ,expr #t) (begin ,@body) *match-fail*))
+   ((eq? form #f) `(if (eq? ,expr #f) (begin ,@body) *match-fail*))
+   ((symbol? form)
+	`(let ((,form ,expr)) ,@body))
+   ((string? form)
+	`(if (equal? ,form ,expr) (begin ,@body) *match-fail*))
+   ((number? form)
+	`(if (= ,form ,expr) (begin ,@body) *match-fail*))
+   ((keyword? form)
+	`(if (eq? ,form ,expr) (begin ,@body) *match-fail*))
+   ((list? form)
+	(let ((pattern-head (car form))
+		  (pattern-body (cdr form)))
+	  (cond 
+	   ((eq? 'let pattern-head)
+		`(let (,@pattern-body) ,@body))
+	   ((eq? 'quote pattern-head)
+		`(if (equal? ,expr ,form)
+			 (begin ,@body)
+			 *match-fail*))
+	   ((eq? 'and pattern-head)
+		(let ((terms (cdr form))
+			  (value-name (gensym 'match-value)))
+		  (if (eq? '() terms)
+			  `(begin ,@body)
+			  `(let ((,value-name ,expr))
+				 (match1-or-fail ,value-name ,(cadr form)
+								 (match1-or-fail ,value-name (and ,@(cddr form)) ,@body))))))
+	   ((eq? 'or pattern-head)
+		(let ((terms (cdr form))
+			  (value-name (gensym 'match-value))
+			  (result-name (gensym 'match-result-value)))
+		  (if (not (apply all-sets-equal? (map pattern-bound-symbols terms)))
+			  (error "shadchen: or patterns must all bind identical symbols."))
+		  (cond 
+		   ((= 0 (length terms))
+			`(begin ,@body))
+		   ((= 1 (length terms))
+			`(match1-or-fail ,expr ,(car terms) ,@body))
+		   (else (let* ((bound-symbols (pattern-bound-symbols (car terms))))
+				   `(let* ((,value-name ,expr)
+						   (,result-name (match1-or-fail ,value-name ,(car terms) (list ,@bound-symbols))))
+					  (if (eq? *match-fail* ,result-name)
+						  (begin 
+							(match1-or-fail ,value-name (or ,@(cdr terms)) ,@body))
+						  (match1-or-fail ,result-name (list ,@bound-symbols) ,@body))))))))
+	   ((eq? 'list pattern-head)
+		(let ((terms (cdr form))
+			  (value-name (gensym 'match-value)))
+		  (cond
+		   ((eq? '() terms)
+			`(let ((,value-name ,expr))
+			   (if (eq? '() ,value-name) (begin ,@body) *match-fail*)))
+		   ((and (= 2 (length terms))
+				 (eq? '... (cadr terms)))
+			(let ((pattern (car terms)))
+			  `(match1-or-fail ,expr ,pattern ,@body)))
+		   (else (let ((sub-pattern (car terms))
+					   (first-value-name (gensym 'first-value)))
+				   `(let ((,value-name ,expr))
+					  (if (or (not (list? ,value-name))
+							  (eq? '() ,value-name)) 
+						  *match-fail*
+						  (let ((,first-value-name (car ,value-name)))
+							(match1-or-fail ,first-value-name ,sub-pattern 
+											(match1-or-fail (cdr ,value-name) (list ,@(cdr terms)) ,@body))))))))))
+	   ((eq? '? pattern-head)
+		(let* ((terms (cdr form))
+			   (predicate-expr (car terms))
+			   (patterns (cdr terms))
+			   (value-name (gensym 'match-value)))
+		  `(let ((,value-name ,expr))
+			 (if (,predicate-expr ,value-name)
+				 (match1-or-fail ,value-name (and ,@patterns) ,@body)
+				 *match-fail*))))
+	   ((eq? 'call pattern-head)
+		(let* ((terms (cdr form))
+			   (transform-expr (car terms))
+			   (patterns (cdr terms)))
+		  `(match1-or-fail (,transform-expr ,expr) (and ,@patterns) ,@body)))
+	   ((eq? 'call* pattern-head)
+		(let* ((terms (cdr form))
+			   (transform-expr (car terms))
+			   (patterns (cdr terms))
+			   (value-name (gensym 'match-value)))
+		  `(let ((,value-name (,transform-expr ,expr)))
+			 (if (eq? ,value-name *match-fail*) *match-fail*
+				 (match1-or-fail ,value-name (and ,@patterns) ,@body)))))
+	   (else 
+		(if (custom-pattern? pattern-head)
+			`(match1-or-fail ,expr ,(apply expand-custom-matcher pattern-head pattern-body) ,@body)
+			(error (string-append "Unknown pattern expander " (symbol->string pattern-head))))))))))
+
+;; Match against a vector (semantics identical to list)
+(define-pattern (vector #!rest patterns)
+  `(and (? vector?)
+		(call vector->list (list ,@patterns))))
+
+;; match against the car and cdr of a pair.
+(define-pattern (pair cr cd)
+  `(and (? pair?)
+		(call (lambda (pair)
+				(list (car pair) (cdr pair)))
+			  (list ,cr ,cd))))
+
+
+(define-macro (match-helper whole-expression value #!rest sub-expressions)
+  (if (eq? '() sub-expressions)
+	  `(error "Match failed:" ,value 'in 'expression: ',whole-expression)
+	  (let* ((sub-expression (car sub-expressions))
+			 (pattern (car sub-expression))
+			 (sub-body (cdr sub-expression))
+			 (sub-expressions (cdr sub-expressions))
+			 (match-result (gensym 'match-result)))
+		`(let ((,match-result (match1-or-fail ,value ,pattern ,@sub-body)))
+		   (if (eq? *match-fail* ,match-result)
+			   (match-helper ,whole-expression ,value ,@sub-expressions)
+			   ,match-result)))))
+
+(define-macro (match value #!rest sub-expressions)
+  (let ((value-name (gensym 'value)))
+	`(let ((,value-name ,value)) 
+	   (match-helper (match ,value ,@sub-expressions)
+					 ,value-name
+					 ,@sub-expressions))))

--- a/modules/shadchen/tests.scm
+++ b/modules/shadchen/tests.scm
@@ -1,0 +1,66 @@
+(include "./shadchen.scm")
+
+(define (display-nl #!rest args)
+  (display args)
+  (newline))
+
+(define-macro (test name predicate expected expr)
+  (let ((predicate-name (gensym 'predicate))
+		(test-result-name (gensym 'test-result))
+		(expected-name (gensym 'expected))
+		(expr-name (gensym 'expr))
+		(name-name (gensym 'name)))
+	`(let ((,expr-name ,expr)
+		   (,expected-name ,expected)
+		   (,predicate-name ,predicate)
+		   (,name-name ,name))
+	   (if (,predicate-name ,expected-name ,expr-name)
+		   (display-nl "success: ",name-name )
+		   (display-nl "FAIL: expected " ,expected-name " got " ,expr-name " which are not equal under " ,predicate)))))
+
+(test "Intentionally fails"
+	  equal?
+	  '(a b c)
+	  '(x y z))
+
+(test "Let inside match expression" 
+	  equal? 10 
+	  (match 'x
+			 ((let (y 10)) y)))
+
+(test "pattern-bound-symbols returns correct symbols for let"
+	  sets-equal? 
+      '(x y)
+	  (pattern-bound-symbols '(let (x 10) (y 11))))
+
+(test "pattern-bound-symbols returns correct symbols for `define-pattern` style matches"
+	  sets-equal?
+	  '(x y)
+	  (pattern-bound-symbols '(vector x y)))
+
+(test "pattern-bound-symbols returns correct symbols for complex match"
+	  sets-equal?
+	  '(x y)
+	  (pattern-bound-symbols '(and (? vector?)
+								   (call vector->list (list x y)))))
+
+(test "default values for match via or and let"
+	  equal?
+	  '(10 11)
+	  (match (list 1 2)
+			 ((or (vector x y) (let (x 10) (y 11)))
+			  (list x y))))
+
+(test "default values not bound in case of success in or/let pattern"
+	  equal? 
+	  '(1 2)
+	  (match (vector 1 2)
+			 ((or (vector x y) (let (x 10) (y 11)))
+			  (list x y))))
+
+(test "false match"
+	  equal?
+	  matched:
+	  (match #f
+			 ((or #f #t)
+			  matched:)))


### PR DESCRIPTION
This code includes (among a few other smaller changes), improved support for looping audio (android, ios and port_audio support) as well as my ml-style pattern-matching language (shadchen), as a module.

