### PR TITLE
Ln_repl define global macros

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -358,6 +358,13 @@ compile_payload()
   if [ -f "$appsrcdir/global-macros.scm" ]; then
     cat "$appsrcdir/global-macros.scm" >> "$globalmacrofile"
   fi
+  # enable all global macros to be visible using ln_repl
+  modpath=`locatedir modules/ln_repl silent`
+  (echo ";; Automatically generated. Do not edit."
+   echo "(define global-macros\n\`("
+   cat "$globalmacrofile"
+   echo "))"
+  ) > "$modpath/*all-global-macros*.scm" 
   #--------
   # step 1: compile and assemble the payload objs
   for lng in $languages; do

--- a/modules/ln_repl/*all-global-macros*.scm
+++ b/modules/ln_repl/*all-global-macros*.scm
@@ -1,0 +1,2 @@
+;; Automatically generated. Do not edit.
+

--- a/modules/ln_repl/ln_repl.scm
+++ b/modules/ln_repl/ln_repl.scm
@@ -125,11 +125,11 @@
     (lambda () (display (exception->string e))))
 		  (##repl-output-port))
   (##newline (##repl-output-port))
-  (##repl-debug))
+  (##repl-debug #f #t))
 
 (define (start-safe-ide-repl)
   (ln-repl-banner)
-  (with-exception-handler ln-repl-exception (lambda () (##repl-debug))))
+  (with-exception-handler ln-repl-exception (lambda () (##repl-debug #f #t))))
 
 (define (repl-server)
   (let ((server

--- a/modules/ln_repl/ln_repl.scm
+++ b/modules/ln_repl/ln_repl.scm
@@ -102,9 +102,6 @@
         (let ((repl-channel (##make-repl-channel-ports in-port out-port)))
         (table-set! repl-channel-table tgroup repl-channel))))
 
-(define (start-ide-repl)
-  (##repl-debug-main))
-
 (define (ln-repl-banner)
   (##write-string "----" (##repl-output-port))
   (##newline (##repl-output-port))

--- a/modules/ln_repl/ln_repl.scm
+++ b/modules/ln_repl/ln_repl.scm
@@ -125,13 +125,11 @@
     (lambda () (display (exception->string e))))
 		  (##repl-output-port))
   (##newline (##repl-output-port))
-  #f)
+  (##repl-debug))
 
 (define (start-safe-ide-repl)
   (ln-repl-banner)
-  (let loop ()
-    (with-exception-catcher ln-repl-exception (lambda () (##repl-debug)))
-    (loop)))
+  (with-exception-handler ln-repl-exception (lambda () (##repl-debug))))
 
 (define (repl-server)
   (let ((server

--- a/modules/ln_repl/ln_repl.scm
+++ b/modules/ln_repl/ln_repl.scm
@@ -4,7 +4,10 @@
 (##namespace ("ln_repl#"))
 (##include "~~lib/gambit#.scm")
 (##namespace ("" system-appname system-appversion exception->string 
-                 fix secondselapsed->string system-buildepoch system-builddatetime))
+                 fix secondselapsed->string system-buildepoch system-builddatetime
+                 read-all))
+
+(include "*all-global-macros*.scm")
 
 (define repl-server-address "*:7000")
 
@@ -129,6 +132,7 @@
   (with-exception-handler ln-repl-exception (lambda () (##repl-debug #f #t))))
 
 (define (repl-server)
+  (map eval global-macros)
   (let ((server
 	 (open-tcp-server
 	  (list server-address: repl-server-address


### PR DESCRIPTION
Another enhancement as per issue #117. This one makes all the globally defined macros (in global-macros.scm files) available at the repl when you connect. It's a bit more involved than the previous change as I changed the make.sh script to create a file *all-global-macros*.scm in the ln_repl module directory. This has all the global macro definitions stashed away so they can be eval'd when a connection is made to the repl.