### PR TITLE
LN_REPL: (#122) Modify build process to always re-build ln_repl module

### DIFF
--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -102,6 +102,10 @@ compile_payload_scm()
           if [ `newersourceindir "$scm_src" "$scm_otgt"` = "yes" ]; then
             scm_dirty=yes
           fi
+	  # ln_repl module special-case: always re-compile to make global macro changes available
+	  if [ "X$scm_topdir" = "Xln_repl" ]; then
+	     scm_dirty=yes
+	  fi
         fi
       fi
       if [ $scm_dirty = yes ]; then


### PR DESCRIPTION
This forces a rebuild of the ln_repl module to ensure that global macros are always up-to-date.  It's a bit heavy-handed, but it doesn't add much to the compile time, and is a much simpler fix than looking at the timestamp of every global-macros.scm file. 