### PR TITLE
Respect the user's XDG Desktop folder on linux

### DIFF
--- a/targets/linux/install
+++ b/targets/linux/install
@@ -38,7 +38,10 @@
 echo "==> attempting to install $SYS_PLATFORM application $SYS_APPNAME to local desktop.."
 pkgfile="$SYS_PREFIXROOT/packages/$(echo $SYS_APPNAME)-$(echo $SYS_APPVERSION)-$(echo $SYS_PLATFORM).zip"
 assertfile $pkgfile
-desktop=$HOME/Desktop
+desktop=`xdg-user-dir DESKTOP` 2> /dev/null
+if [ "x$desktop" = "x" ]; then
+   desktop=$HOME/Desktop
+fi
 if [ ! -d "$desktop" ]; then 
   mkdir -p "$desktop"
 fi


### PR DESCRIPTION
Changes from a hard-coded "Desktop" folder to the user's choice configured using XDG tool. Falls back to hard-coded choice if this is not available.