### PR TITLE
Support x86 and don't expect android ndk version 4.8 on linux

### DIFF
--- a/targets/android/host_linux
+++ b/targets/android/host_linux
@@ -61,6 +61,7 @@ android_customtoolchain=${SYS_PREFIX}/${android_ndkver}-${ANDROIDARCH}-${ANDROID
 if [ ! -d $android_customtoolchain ]; then
   $ANDROIDNDK/build/tools/make-standalone-toolchain.sh \
      --toolchain=${android_chain} \
+     --arch=$ANDROIDARCH \
      --platform=android-${ANDROIDAPI} \
      --install-dir=$android_customtoolchain \
      --ndk-dir=${ANDROIDNDK}

--- a/targets/android/host_linux
+++ b/targets/android/host_linux
@@ -54,7 +54,7 @@ if [ ! "X$android_apichanged" = "X" ]; then
   echo "$android_apichanged"
 fi
 
-android_chainpath=`ls -1d $ANDROIDNDK/toolchains/${ANDROIDARCH}*-4.8 | head -n 1`
+android_chainpath=`ls -1d $ANDROIDNDK/toolchains/${ANDROIDARCH}*-4.* | head -n 1`
 android_chain=`basename "$android_chainpath"`
 android_ndkver=`basename "$ANDROIDNDK"`
 android_customtoolchain=${SYS_PREFIX}/${android_ndkver}-${ANDROIDARCH}-${ANDROIDAPI}-toolchain


### PR DESCRIPTION
In other words: a68aa5f4219a8ee512a8a25ed9ebef3adf4c4888 for linux hosts.

I also had to remove the `--ndk-dir` argument since the script told me it is no longer supported. I am using ndk r13.