### PR TITLE
ORIENTATION: add check for inverted orientation (seascape/upsidedown)

### DIFF
--- a/modules/orientation/orientation.scm
+++ b/modules/orientation/orientation.scm
@@ -43,6 +43,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (define (orientation-portrait?) (not (orientation-landscape?)))
 
+(define (orientation-inverted?)
+  (or (= orientation:state GUI_SEASCAPE) (= orientation:state GUI_UPSIDEDOWN)))
+
 (define (orientation-event t x y . opt)
   (if (and (= t EVENT_ORIENTATION) 
         (if (fx> (length opt) 0) (member x opt) #t)) (begin


### PR DESCRIPTION
Current implementation doesn't provide a function to distinguish inverted orientations. Could add a separate check for each orientation but this allows the existing behaviour to be unchanged (ie landscape/portrait is considered to be either of two orientations).