### PR TITLE
Handle compilation and permissions for ANDROIDAPI>22.

### DIFF
--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -111,7 +111,7 @@ public class @SYS_APPNAME@ extends Activity implements @ANDROID_JAVA_IMPLEMENTS@
     setContentView(mGLView);
     mSensorManager = (SensorManager)getSystemService(Context.SENSOR_SERVICE);
 
-    /* Included @IF_ANDROIDAPI_GT_22@
+    @IF_ANDROIDAPI_GT_22@
     if (getApplicationContext().checkCallingOrSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
         !=  android.content.pm.PackageManager.PERMISSION_GRANTED) {
         requestPermissions(new String[] { android.Manifest.permission.WRITE_EXTERNAL_STORAGE }, 1);

--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -75,6 +75,7 @@ public class @SYS_APPNAME@ extends Activity implements @ANDROID_JAVA_IMPLEMENTS@
   //Variable declarations needed for modules, e.g. gps
   @ANDROID_JAVA_VARIABLES@
 
+  int idle_tmScheduleRate = 250;
   Timer idle_tm = new Timer();
   TimerTask idle_task = new TimerTask() {
     public void run() {
@@ -109,11 +110,20 @@ public class @SYS_APPNAME@ extends Activity implements @ANDROID_JAVA_IMPLEMENTS@
     mGLView = new xGLSurfaceView(this);
     setContentView(mGLView);
     mSensorManager = (SensorManager)getSystemService(Context.SENSOR_SERVICE);
+
+    /* Included @IF_ANDROIDAPI_GT_22@
+    if (getApplicationContext().checkCallingOrSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        !=  android.content.pm.PackageManager.PERMISSION_GRANTED) {
+        requestPermissions(new String[] { android.Manifest.permission.WRITE_EXTERNAL_STORAGE }, 1);
+        // startActivity(new Intent(android.provider.Settings.ACTION_MEMORY_CARD_SETTINGS).setData(Uri.parse("package:"+"@SYS_PACKAGE_DOT@")));
+    }
+    /* end of IF_ANDROIDAPI_GT_22 */
+
     // Additions needed by modules, e.g. gps
     @ANDROID_JAVA_ONCREATE@
 
     // start EVENT_IDLE 
-    idle_tm.scheduleAtFixedRate(idle_task, 0, 250);
+    if(idle_tmScheduleRate > 0) idle_tm.scheduleAtFixedRate(idle_task, 0, idle_tmScheduleRate);
 
     nativeInstanceInit();
   }

--- a/make.sh
+++ b/make.sh
@@ -1032,6 +1032,7 @@ make_setup_target()
   ac_subst SYS_APPVERSION
   ac_subst SYS_APPVERSIONCODE
   ac_subst SYS_ANDROIDAPI
+  ac_subst IF_ANDROIDAPI_GT_22 "`if [ $SYS_ANDROIDAPI -lt 23 ]; then echo 'commented out:'; else echo 'active here:*/'; fi`"
   ac_subst SYS_ANDROIDSDK
   ac_subst SYS_ANDROIDNDK
   ac_subst SYS_ANDROIDARCH

--- a/make.sh
+++ b/make.sh
@@ -1032,7 +1032,7 @@ make_setup_target()
   ac_subst SYS_APPVERSION
   ac_subst SYS_APPVERSIONCODE
   ac_subst SYS_ANDROIDAPI
-  ac_subst IF_ANDROIDAPI_GT_22 "`if [ $SYS_ANDROIDAPI -lt 23 ]; then echo '/* commented out:'; else echo '/* active here:*/'; fi`"
+  ac_subst IF_ANDROIDAPI_GT_22 "`if [ $SYS_ANDROIDAPI -lt 23 ]; then echo '/* IF_ANDROIDAPI_GT_22 commented out:'; else echo '/* IF_ANDROIDAPI_GT_22 active here:*/'; fi`"
   ac_subst SYS_ANDROIDSDK
   ac_subst SYS_ANDROIDNDK
   ac_subst SYS_ANDROIDARCH

--- a/make.sh
+++ b/make.sh
@@ -1032,7 +1032,7 @@ make_setup_target()
   ac_subst SYS_APPVERSION
   ac_subst SYS_APPVERSIONCODE
   ac_subst SYS_ANDROIDAPI
-  ac_subst IF_ANDROIDAPI_GT_22 "`if [ $SYS_ANDROIDAPI -lt 23 ]; then echo 'commented out:'; else echo 'active here:*/'; fi`"
+  ac_subst IF_ANDROIDAPI_GT_22 "`if [ $SYS_ANDROIDAPI -lt 23 ]; then echo '/* commented out:'; else echo '/* active here:*/'; fi`"
   ac_subst SYS_ANDROIDSDK
   ac_subst SYS_ANDROIDNDK
   ac_subst SYS_ANDROIDARCH

--- a/modules/ln_core/packtool.scm
+++ b/modules/ln_core/packtool.scm
@@ -56,6 +56,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;; extract an embedded file
 (define (packtool-unpack file cdata overwrite)
+  (let ((rootpath (system-directory)))
+    (if (not (file-exists? rootpath)) (create-directory rootpath)))
   (let ((path (packtool:prep file)))
     (if (or overwrite (not (file-exists? path)))
       (let ((data (u8vector-decompress cdata)))


### PR DESCRIPTION
Since Marshmallow permissions are not automatically granted as
specified in the Manifest.

As a consequence LN apps die when accessing the SDCard, e.g. when
unpacking embedded files.

This patch adds a fragile hack to enable an ifdef-alike trick to
exclude code portions when targeting older APIs and uses it to request
the permission at startup.  Plus create the system-directory if it
does not already exists.