### PR TITLE
Err on usability wrt. clipboard content.

### DIFF
--- a/modules/clipboard/clipboard.scm
+++ b/modules/clipboard/clipboard.scm
@@ -225,7 +225,13 @@ int clipboard_hascontent(){
   return macosx_clipboard_hascontent();
 #endif
 
-  return 0;
+  /* FIXME: Actually check win32 and linux.  However it's bettert to
+   * provide a false positive claiming content (thus suggesting to the
+   * user to paste is even though that would fail) than falsely claim
+   * nothing available thus preventing avail content to be pasted.
+   */
+
+  return 1;
 }
 
 end-of-c-declare


### PR DESCRIPTION
On linux and win32 the code does so far not know whether or not the
clipboard has any content.

That's NOT changed by this patch.

However it's IMHO better to provide a false positive claiming
content (thus suggesting to the user to paste is even though that
would fail) than falsely claim nothing available thus preventing avail
content to be pasted.