### PR TITLE
Tag mutex in ide-repl-pump

### DIFF
--- a/modules/ln_repl/ln_repl.scm
+++ b/modules/ln_repl/ln_repl.scm
@@ -10,7 +10,7 @@
 (define repl-server-address "*:7000")
 
 (define (ide-repl-pump ide-repl-connection in-port out-port tgroup)
-  (define m (make-mutex))
+  (define m (make-mutex (gensym 'ide-repl-pump)))
   (define (process-input)
     (let loop ((state 'normal))
       (let ((c (read-char ide-repl-connection)))


### PR DESCRIPTION
Caveat: This code is untested AND I don't understand the code!!!

Somehow the procedure `ide-repl-pump` is called in recursiv manner,
which will create a fresh mutex.  I don't see which ressource exactly
this mutex is supposed to protect.  Hence I do not understand whether
or not it is correct to actually allocate two different mutexs here.

PLEASE review this with care to ensure we don't create two mutexes to
protec the same ressource and hence fail to protect it at all.