### PR TITLE
Name mutex with the symbol they are bound to.

### DIFF
--- a/modules/ln_store/data.scm
+++ b/modules/ln_store/data.scm
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   (store:setlocal! store "extern:clear!" proc))
 
 ;; thread-safe access to data stores
-(define store:mutex (make-mutex))
+(define store:mutex (make-mutex 'store:mutex))
 (define (store:grab!) (mutex-lock! store:mutex))
 (define (store:release!) (mutex-unlock! store:mutex))
 

--- a/modules/rupi/rupicore.scm
+++ b/modules/rupi/rupicore.scm
@@ -124,7 +124,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;; %%%%%%%%%%%%%%%%%%%%%%%%%%%
 ;; client
 
-(define rupi:mutex (make-mutex))
+(define rupi:mutex (make-mutex 'rupi:mutex))
 (define (rupi:grab!) (mutex-lock! rupi:mutex))
 (define (rupi:release!) (mutex-unlock! rupi:mutex))
 


### PR DESCRIPTION
grep does not show any more make-mutex (except for the one in `ide-repl-pump`) to be named.