### PR TITLE
Enable use of cond-expand depending on SYS_PLATFORM.

### DIFF
--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -56,6 +56,7 @@ compile_payload_scm()
     else
       scm_opts="(declare (block)(not safe)(standard-bindings)(extended-bindings))"
     fi
+    scm_opts="${scm_opts}(define-cond-expand-feature $SYS_PLATFORM)"
     # support global macro definitions
     if [ -f "${SYS_HOSTPREFIX}/lib/global-macros.scm" ]; then
       scm_opts="${scm_opts}(include \\\"~~lib/global-macros.scm\\\")"


### PR DESCRIPTION
This change allows to use things like
   (cond-expand
    (android ...code applicable on android targets only...)
    (linux ...code applicable on linux targets only...)
    (else ...code applicable on all other targets...))

NB:

1. According to SRFI-0 `cond-expand` is only mandatory on top level.
2. Most Scheme implementations (i.e., all I know of), including gambit
   allow the use of `cond-expand` everywhere.
3. With this change all uses of `app:android?` at runtime could
   eventually be replaced by compile time code expansion.