### PR TITLE
Android: APIVERSION in file names of cache directory and package.

### DIFF
--- a/SETUP.template
+++ b/SETUP.template
@@ -6,6 +6,9 @@ ANDROIDSDK=`find /usr/local/android-sdk-*  -maxdepth 0 -print 2> /dev/null | tai
 ANDROIDNDK=`find /usr/local/android-ndk-*  -maxdepth 0 -print  2> /dev/null| tail -n 1`
 # minimum version to support (a matching target must be installed)
 ANDROIDAPI=19
+if [ "$SYS_PLATFORM" = "android" ]; then
+  SYS_PLATFORM_VARIANT="-api${ANDROIDAPI}"
+fi
 #android target cpu, either arm (default), x86 or mips
 ANDROIDARCH=arm
 # Java source and target version (default 1.5 when unset, set 1.6 to allow using Java 9/10)

--- a/make.sh
+++ b/make.sh
@@ -952,7 +952,7 @@ make_setup_target()
   setup_target=$1
   assertfile $setup_target "Don't know how to setup a build for $SYS_PLATFORM on a $SYS_HOSTPLATFORM host"
   ac_reset
-  SYS_PREFIX="$SYS_PREFIXROOT/$SYS_PLATFORM"
+  SYS_PREFIX="${SYS_PREFIXROOT}/${SYS_PLATFORM}${SYS_PLATFORM_VARIANT}"
   #--------
   # register custom compiler/linker options
   payload_spcaps=`echo $SYS_PLATFORM | tr 'a-z' 'A-Z'`

--- a/targets/android/build-binary
+++ b/targets/android/build-binary
@@ -315,7 +315,7 @@ pkgfile="$tmpdir/bin/$(echo $SYS_APPNAME)-release-unsigned.apk"
 assertfile "$pkgfile"
 
 echo " => transferring application.."
-fnlfile=$SYS_PREFIXROOT/packages/$(echo $SYS_APPNAME)-$(echo $SYS_APPVERSION)-android.apk
+fnlfile=$SYS_PREFIXROOT/packages/$(echo $SYS_APPNAME)-$(echo $SYS_APPVERSION)-android${SYS_PLATFORM_VARIANT}.apk
 cp $pkgfile $fnlfile
 assertfile $fnlfile
 

--- a/targets/android/package
+++ b/targets/android/package
@@ -35,7 +35,7 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pkgfile="$SYS_PREFIXROOT/packages/$(echo $SYS_APPNAME)-$(echo $SYS_APPVERSION)-$(echo $SYS_PLATFORM).apk"
+pkgfile="$SYS_PREFIXROOT/packages/$(echo $SYS_APPNAME)-$(echo $SYS_APPVERSION)-$(echo $SYS_PLATFORM)${SYS_PLATFORM_VARIANT}.apk"
 assertfile $pkgfile
 echo "=== $pkgfile"
 


### PR DESCRIPTION
This should shell you from the confusion developing for several API
versions.  (Or the tidious need to wait for `make scrub` every time.)