### PR TITLE
Fix of Issue #234

### DIFF
--- a/modules/ln_glcore/glcore-ffi.scm
+++ b/modules/ln_glcore/glcore-ffi.scm
@@ -161,6 +161,10 @@ ___result = GL_CLAMP_TO_EDGE;
 
 (define glPopMatrix (c-lambda () void "glPopMatrix"))
 
+(define glIsEnabled (c-lambda (int) int "glIsEnabled"))
+
+(define glGetError (c-lambda () int "glGetError"))
+
 (define (glTranslatef a b c) 
   ((c-lambda (float float float) void "glTranslatef") 
      (flo a) (flo b) (flo c)))

--- a/modules/ln_glcore/glcore.scm
+++ b/modules/ln_glcore/glcore.scm
@@ -376,9 +376,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   (if entry (begin
     (if (not (vector-ref entry 0)) (_glCoreTextureInit t))
     (let ((tx (u32vector-ref (vector-ref entry 1) 0)))
-      (if (not (= glCore:curtexture tx))
+      (if (not (= glCore:curtexture tx)) (begin
         (glBindTexture GL_TEXTURE_2D tx)
-        (set! glCore:curtexture tx)))
+        (set! glCore:curtexture tx))))
     ) (log-error "glCoreTextureBind: unbound index " t)
  )))
 
@@ -393,7 +393,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
          (interp  (vector-ref entry 6))
          (wrap  (vector-ref entry 7)))
     (glGenTextures 1 u32t)  
-    (if (= (u32vector-ref u32t 0) GL_INVALID_VALUE) 
+    (if (or (= (u32vector-ref u32t 0) GL_INVALID_VALUE)
+      ;this is a general check that gl is working in this thread
+            (= (glIsEnabled GL_TEXTURE_2D) 0))  
        (log-error "_glCoreTextureInit: failed to generate texture")
        (begin
          (vector-set! entry 0 #t)  ;; mark as initialized


### PR DESCRIPTION
[Issue #234](https://github.com/part-cw/lambdanative/issues/234). 

The issue is that `_glCoreTextureCreate` sometimes does not properly set up the texture, but marks it as initialized anyway. This fix adds a further check on the proper operation of the GL Context, creates an error, and lets the texture be re-initialized on next call. I believe this stems from being called in a different thread from the main GL Context. 

This also fixes what I believe to be a typo in `_glCoreTextureBind`, and adds helpful functions `glGetError` and `glIsEnabled` to glcore-ffi.scm