### PR TITLE
SCM: add target specific directory definition to gambit invocation

### DIFF
--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -121,7 +121,7 @@ compile_payload_scm()
 	if [ -f $scm_hdr ]; then scm_hdr="-e '(load \"$scm_hdr\")'"; else scm_hdr=""; fi
 	gsc_processing=""
 	# if [ $SYS_VERBOSE ]; then gsc_processing="$gsc_processing -expansion"; fi
-        veval "$SYS_GSC -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
+        veval "$SYS_GSC -:~~tgtlib=${SYS_PREFIX}/lib -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
         if [ $veval_result != "0" ]; then rmifexists "$scm_ctgt"; fi
         assertfile "$scm_ctgt"
         rmifexists "$scm_otgt"

--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -121,7 +121,7 @@ compile_payload_scm()
 	if [ -f $scm_hdr ]; then scm_hdr="-e '(load \"$scm_hdr\")'"; else scm_hdr=""; fi
 	gsc_processing=""
 	# if [ $SYS_VERBOSE ]; then gsc_processing="$gsc_processing -expansion"; fi
-        veval "$SYS_GSC -:~~tgtlib=${SYS_PREFIX}/lib -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
+        veval "$SYS_GSC -:~~tgt=${SYS_PREFIX} -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
         if [ $veval_result != "0" ]; then rmifexists "$scm_ctgt"; fi
         assertfile "$scm_ctgt"
         rmifexists "$scm_otgt"


### PR DESCRIPTION
Gambit allows to refer to various installation dependent directories
using the ~~NAME symtax - e.g., as in `(include "~~lib/my/file.scm")`.
However gambit is not aware of cross-compiling.  So `~~lib` will refer
to the hosts version.

This change adds another option to the gambit invocation, which allows
to distinguish between the host and the target specific files of
gambit.  At least for the library.

The use case this is required for is not (yet) publically available.
It involves a library wich includes gambit source code using
cond-expand to include use cases like file locking for instance -
which is a horror to provide in a platform agnostic way.