### PR TITLE
LNCORE: avoid SEGV in list-head

### DIFF
--- a/modules/ln_core/list.scm
+++ b/modules/ln_core/list.scm
@@ -51,7 +51,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;    (if (>= n len) l
 ;;      (reverse (list-tail (reverse l) (- len n))))))
 (define (list-head l k)
-  (if (= k 0) '()
+  (if (or (= k 0) (null? l)) '()
       (cons (car l) (list-head (cdr l) (- k 1)))))
 
 


### PR DESCRIPTION
Changes implementation to not error out with a segmentation fault if
the list fed into list-head is shorter than the maximum length
requested by the call.