### PR TITLE
GLGUI: reduce idle load

### DIFF
--- a/loaders/common/main.c
+++ b/loaders/common/main.c
@@ -82,24 +82,24 @@ void signal_hook()
 void microgl_hook(int t, int x, int y)
 {
   switch (t) {
-    case EVENT_REDRAW: 
+    case EVENT_REDRAW:
       glClearColor(0.0, 0.0, 0.0, 0.0);
-      glMatrixMode(GL_PROJECTION);	
+      glMatrixMode(GL_PROJECTION);
       glLoadIdentity();
       glOrtho(0.,scm_width(),0.,scm_height(),-1.,1.);
-      glMatrixMode(GL_MODELVIEW);	
+      glMatrixMode(GL_MODELVIEW);
       glLoadIdentity();
       glClear(GL_COLOR_BUFFER_BIT);
       ffi_event(EVENT_REDRAW,0,0);
       microgl_swapbuffers();
       break;
-    case EVENT_CLOSE: 
+    case EVENT_CLOSE:
       ffi_event(EVENT_CLOSE,0,0);
       run_flag=0;
-      break; 
+      break;
     default:
       ffi_event(t,x,y);
-      break; 
+      break;
   }
 }
 
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
 
   // determine width and height of display
   w=microgl_screenwidth(); h=microgl_screenheight();
-  
+
 #endif // USECONSOLE
 
   // allow payload to initialize
@@ -159,10 +159,10 @@ int main(int argc, char *argv[])
   } else {
     microgl_window(scm_width(),scm_height());
   }
- 
+
 #endif // USECONSOLE
 
-  while (run_flag) { 
+  while (run_flag) {
     // check for application exit
     if (run_flag) run_flag=scm_runflag();
 
@@ -173,20 +173,11 @@ int main(int argc, char *argv[])
     // ask for a redraw
     microgl_refresh();
 
-#else 
-  
+#else
+
    // generate a fake redraw event
     ffi_event(EVENT_REDRAW,0,0);
 
-#endif // USECONSOLE
-
-#ifndef USECONSOLE
-    // sleep 10ms...
-#ifdef WIN32
-    Sleep(10);  
-#else
-    usleep(10000);
-#endif
 #endif // USECONSOLE
 
    }
@@ -200,4 +191,3 @@ int main(int argc, char *argv[])
 
   return 1;
 }
-

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -316,9 +316,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                   (apply glgui:inputloop (append (list t x0 y0) gs)))))
           (if (fx= t EVENT_REDRAW)
               (wait-for-time-or-signal!)
-              (begin
-                (thread-sleep! step)
-                (reset-wait!)))))
+              (if frame-period-custom
+                  (thread-sleep! (frame-period-custom 1))
+                  (begin
+                    (thread-sleep! step)
+                    (reset-wait!))))))
     (set! glgui-wakeup! wakeup!)
     (set! glgui-timings-set! timings-set!)
     glgui-event))

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -329,7 +329,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   (define (wait-for-sec _) (seconds->time (+ ##now sec)))
   (define (no-wait _) 0)
   (cond-expand
-   ((or android iod)
+   ((or android ios)
     ;; TBD: convey the time value to signaling code.
     ;; switch delays to zero
     (glgui-timings-set! frame-period-custom: no-wait))
@@ -338,7 +338,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 (define (glgui-timings-at-10msec!) (glgui-timings-at-sec! 0.01))
 
 (cond-expand
- ((or android iod)
+ ((or android ios)
   ;; 50 Hz should be enough - TBD: not yet effective
   (glgui-timings-at-sec! 0.02))
  (else))

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -250,9 +250,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;
 ;; Examples:
 ;;
-;;  (glgui-timings-set! frame-period-max: 2 frame-period-min: 0.01) -- start with 110/sec down to 0.5/sec
+;;  (glgui-timings-set! frame-period-max: 2 frame-period-min: 0.01) -- start with 100/sec down to 0.5/sec
 ;;  (glgui-timings-set! frame-period-max: 0.5 frame-period-min: 0.05) -- 20/sec down to 2/sec
 ;;  (glgui-timings-set! frame-period-custom: (lambda (x) 0.01))  -- constant 100/sec
+;;
+;;  When concerned about a precise frame rate take a hint from gambit
+;;  manual wrt. `thread-sleep!` and wait until a point in time no
+;;  matter how long it took to process events and render the GUI:
+;;
+;; (glgui-timings-set!
+;;  frame-period-custom:
+;;  (let ((last-frame-time (current-time-seconds))
+;;        (frame-period 0.05))
+;;    (lambda (x) ;; ignoring `x`
+;;      (let* ((now (current-time-seconds))
+;;             (next (+ last-frame-time frame-period)))
+;;        (set! last-frame-time now)
+;;        (seconds->time next)))))
 
 (define glgui-timings-set!)
 

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -263,9 +263,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;  (let ((last-frame-time (current-time-seconds))
 ;;        (frame-period 0.05))
 ;;    (lambda (x) ;; ignoring `x`
-;;      (let* ((now (current-time-seconds))
-;;             (next (+ last-frame-time frame-period)))
-;;        (set! last-frame-time now)
+;;      (let ((next (+ last-frame-time frame-period)))
+;;        (set! last-frame-time next)
 ;;        (seconds->time next)))))
 
 (define glgui-timings-set!)

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -308,15 +308,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       (if (and glgui:active app:width app:height)
           (let ((gs (if (list? guis) guis (list guis))))
             (if (fx= t EVENT_REDRAW)
-                (if (mutex-lock! wait-mutex 0)
-                  (begin
-                    (apply glgui:render gs)
-                    (wait-for-time-or-signal!)
-                  )
-                  (begin
-                    (reset-wait!)
-                    (apply glgui:inputloop (append (list t x0 y0) gs))
-                  )))
+                (when (mutex-lock! wait-mutex 0)
+                  (apply glgui:render gs)
+                  (wait-for-time-or-signal!))
+                (begin
+                  (reset-wait!)
+                  (apply glgui:inputloop (append (list t x0 y0) gs)))))
           (if (fx= t EVENT_REDRAW)
               (wait-for-time-or-signal!)
               (if frame-period-custom

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -312,11 +312,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                   (begin
                     (apply glgui:render gs)
                     (wait-for-time-or-signal!)
-                  ))
-                (begin
-                  (reset-wait!)
-                  (apply glgui:inputloop (append (list t x0 y0) gs))
-                )))
+                  )
+                  (begin
+                    (reset-wait!)
+                    (apply glgui:inputloop (append (list t x0 y0) gs))
+                  )))
           (if (fx= t EVENT_REDRAW)
               (wait-for-time-or-signal!)
               (if frame-period-custom

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -323,6 +323,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     (set! glgui-timings-set! timings-set!)
     glgui-event))
 
+(define glgui-timings-at-10msec!
+  (let ((wait-for-10ms (lambda (_) (seconds->time (+ ##now 0.01)))))
+    (lambda ()
+      (glgui-timings-set! frame-period-custom: wait-for-10ms))))
+
 ;; provide a screen shot
 (define (glgui-screenshot)
   (let ((w (glgui-width-get))

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -325,10 +325,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     (set! glgui-timings-set! timings-set!)
     glgui-event))
 
-(define glgui-timings-at-10msec!
-  (let ((wait-for-10ms (lambda (_) (seconds->time (+ ##now 0.01)))))
-    (lambda ()
-      (glgui-timings-set! frame-period-custom: wait-for-10ms))))
+(define (glgui-timings-at-msec! msec)
+  (define (wait-for-msec _) (seconds->time (+ ##now msec)))
+  (define (no-wait _) 0)
+  (cond-expand
+   ((or android iod)
+    ;; TBD: convey the msec value to signaling code.
+    ;; switch delays to zero
+    (glgui-timings-set! frame-period-custom: no-wait))
+   (else (glgui-timings-set! frame-period-custom: wait-for-msec))))
+
+(define (glgui-timings-at-10msec!) (glgui-timings-at-msec! 0.01))
+
+(cond-expand
+ ((or android iod)
+  ;; 50 Hz should be enough - TBD: not yet effective
+  (glgui-timings-at-msec! 0.02))
+ (else))
 
 ;; provide a screen shot
 (define (glgui-screenshot)

--- a/modules/ln_glgui/glgui.scm
+++ b/modules/ln_glgui/glgui.scm
@@ -325,22 +325,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     (set! glgui-timings-set! timings-set!)
     glgui-event))
 
-(define (glgui-timings-at-msec! msec)
-  (define (wait-for-msec _) (seconds->time (+ ##now msec)))
+(define (glgui-timings-at-sec! sec)
+  (define (wait-for-sec _) (seconds->time (+ ##now sec)))
   (define (no-wait _) 0)
   (cond-expand
    ((or android iod)
-    ;; TBD: convey the msec value to signaling code.
+    ;; TBD: convey the time value to signaling code.
     ;; switch delays to zero
     (glgui-timings-set! frame-period-custom: no-wait))
-   (else (glgui-timings-set! frame-period-custom: wait-for-msec))))
+   (else (glgui-timings-set! frame-period-custom: wait-for-sec))))
 
-(define (glgui-timings-at-10msec!) (glgui-timings-at-msec! 0.01))
+(define (glgui-timings-at-10msec!) (glgui-timings-at-sec! 0.01))
 
 (cond-expand
  ((or android iod)
   ;; 50 Hz should be enough - TBD: not yet effective
-  (glgui-timings-at-msec! 0.02))
+  (glgui-timings-at-sec! 0.02))
  (else))
 
 ;; provide a screen shot

--- a/modules/ln_glgui/ln_glgui.scm
+++ b/modules/ln_glgui/ln_glgui.scm
@@ -36,6 +36,23 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 |#
 
+(define-macro (define-cond-expand-feature-value v)
+  (let ((v (eval v)))
+    `(define-cond-expand-feature ,v)))
+
+(define-cond-expand-feature-value
+  (if (>= (system-version) 409002)
+      'gambit-4.7.9
+      'gambit-4.9+))
+
+(cond-expand
+ (gambit-4.7.9
+  (define-macro (when test expr . rest)
+    `(if ,test (begin ,expr ,@rest)))
+  (define-macro (unless test expr . rest)
+    `(if (not ,test) (begin ,expr ,@rest))))
+ (else))
+
 (include "glgui_button.scm")
 (include "glgui_keypad_delete.scm")
 (include "glgui_keypad_return.scm")


### PR DESCRIPTION
Note: When other threads notice that the GUI thread should stop
waiting and thus reducing responsiveness : call `(glgui-wakeup!)` .