### PR TITLE
[REDCAP] adds redcap-project-info and optimises the redcap-import-file

### DIFF
--- a/modules/redcap/redcap.scm
+++ b/modules/redcap/redcap.scm
@@ -419,7 +419,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                           (cond
                             ((not (list? datalist))
                               ;; If no list returned, json not properly formatted
-                              (log-error "REDCap error: Incomplete json" msg)
+                              (log-error "REDCap error: Incomplete json " msg)
                               #f)
                             ((and (fx> (length datalist) 0) (string=? (caaar datalist) "error\""))
                               ;; If the first entry is an error, then log it and return false
@@ -470,7 +470,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                      (cond
                        ((not (list? datalist))
                          ;; If no list returned, json not properly formatted
-                         (log-error "REDCap error: Incomplete json" output)
+                         (log-error "REDCap error: Incomplete json " output)
                          #f)
                        ((and (fx> (length datalist) 0) (string=? (caaar datalist) "error\""))
                          ;; If the first entry is an error, then log it and return false


### PR DESCRIPTION
get fields such as get fields such as project_id, project_title, creation_time, production_time, in_production, project_language, purpose, purpose_other, project_notes, custom_record_label, secondary_unique_field, is_longitudinal, has_repeating_instruments_or_events, surveys_enabled, scheduling_enabled, record_autonumbering_enabled, randomization_enabled, ddp_enabled, project_irb_number, project_grant_number, project_pi_firstname, project_pi_lastname, display_today_now_button, missing_data_codes, external_modules
;; requires to run redcap v >10.0 on host to function properly


