### PR TITLE
CONFIG: replace version detection with native gambit feature

### DIFF
--- a/modules/config/config.scm
+++ b/modules/config/config.scm
@@ -39,18 +39,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;; init.scm
 ;; this is the glue between the native launcher and the portable code
 
-(define-macro (define-cond-expand-feature-value v)
-  (let ((v (eval v)))
-    `(define-cond-expand-feature ,v)))
-
-(define-cond-expand-feature-value
-  (if (>= (system-version) 409002)
-      'heartbeat-interval-2019
-      'heartbeat-interval-legacy))
-
 (cond-expand
- (heartbeat-interval-2019 (if (string=? (system-platform) "android") (##set-heartbeat-interval! -1.)))
- (else (if (string=? (system-platform) "android") (##heartbeat-interval-set! -1.))))
+ (gambit-c (if (string=? (system-platform) "android") (##heartbeat-interval-set! -1.)))
+ (else (if (string=? (system-platform) "android") (##set-heartbeat-interval! -1.))))
 
 (c-declare  #<<end-of-c-declare
 


### PR DESCRIPTION
While looking into patching gambc to support `when` and `unless` I discovered a better way to detect the gambit version.