### PR TITLE
SCM: in debug mode: enable more debugging

### DIFF
--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -52,7 +52,7 @@ compile_payload_scm()
     # -------
     # prep the compiler options
     if [ $SYS_MODE = "debug" ]; then
-      scm_opts="(declare (block)(not safe)(standard-bindings)(extended-bindings)(debug)(debug-location))"
+      scm_opts="(declare (standard-bindings)(extended-bindings)(debug)(debug-location))"
     else
       scm_opts="(declare (block)(not safe)(standard-bindings)(extended-bindings))"
     fi

--- a/modules/ln_core/ln_core.scm
+++ b/modules/ln_core/ln_core.scm
@@ -37,9 +37,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 |#
 
 (include "unit-test.scm")
+(include "flofix.scm")
 (include "color.scm")
 (include "floatstring.scm")
-(include "flofix.scm")
 (include "list.scm")
 (include "math.scm")
 (include "list-stats.scm")


### PR DESCRIPTION
The gambit optimizations `(block)` and `(not safe)` are annoying in
debug mode.

Without `(block)` we gain the ability to instrument global definitions.

Without `(not safe)` we gain Scheme-level errors for segmentation faults.

In case we need something in between, we better introduce additional option (or sub-options) like `stage` - which would apply all optimizations but still include instrumentation - and/or more to remove instrumentation but keep out optimizations.

Maybe just --- hm, have a way to override these things per module ;-).  THAT would enable us to inject variants via `SETUP` or other tricks.
