### PR TITLE
EVENTLOOP adds backward compatible option to disable mediascanner 

### DIFF
--- a/modules/eventloop/eventloop.scm
+++ b/modules/eventloop/eventloop.scm
@@ -256,12 +256,13 @@ end-of-c-declare
 ;; override gambit main definition for backwards compatibility
 (set! main ln-main)
 
-(define (terminate)
+(define (terminate . nomediascanner)
   (if app:android? (begin
-    (android-run-mediascanner)
-    (android-finish)
-    (let loop ()
-      (if (not android-mediascanner-done?) (begin (thread-sleep! 0.1) (loop))))))
+    (let ((nm (not (if (= (length nomediascanner) 1) (car nomediascanner) #f))))
+     (if nm (android-run-mediascanner))
+     (android-finish)
+     (if nm (let loop ()
+      (if (not android-mediascanner-done?) (begin (thread-sleep! 0.1) (loop))))))))
   (if (procedure? hook:terminate) (hook:terminate))
 )
 

--- a/modules/eventloop/eventloop.scm
+++ b/modules/eventloop/eventloop.scm
@@ -257,12 +257,13 @@ end-of-c-declare
 (set! main ln-main)
 
 (define (terminate . nomediascanner)
-  (if app:android? (begin
-    (let ((nm (not (if (= (length nomediascanner) 1) (car nomediascanner) #f))))
-     (if nm (android-run-mediascanner))
-     (android-finish)
-     (if nm (let loop ()
-      (if (not android-mediascanner-done?) (begin (thread-sleep! 0.1) (loop))))))))
+  (if app:android?
+    (let ((run-mediascanner? (if (= (length nomediascanner) 1) (not (car nomediascanner)) #t)))
+      (if run-mediascanner? (android-run-mediascanner))
+      (android-finish)
+      (if run-mediascanner?
+        (let loop ()
+          (if (not android-mediascanner-done?) (begin (thread-sleep! 0.1) (loop)))))))
   (if (procedure? hook:terminate) (hook:terminate))
 )
 


### PR DESCRIPTION
Disables mediscanner on android when terminating.

Provides temporary fix for #295 for those that need it, at least for API <25 (only ones tested)