### PR TITLE
EVENTLOOP: add required declarations

### DIFF
--- a/modules/eventloop/eventloop.scm
+++ b/modules/eventloop/eventloop.scm
@@ -36,6 +36,10 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 |#
 
+(declare
+ (block)
+ (not interrupts-enabled))
+
 (c-declare  #<<end-of-c-declare
 
 #include "LNCONFIG.h"


### PR DESCRIPTION
Without `(block)` this module fails to link properly.