### PR TITLE
BUILD: export well known build parameters to gambit compiler

### DIFF
--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -129,7 +129,11 @@ compile_payload_scm()
           gsc_processing=""
         fi
 	# if [ $SYS_VERBOSE ]; then gsc_processing="$gsc_processing -expansion"; fi
-        veval "$SYS_GSC -:~~tgt=${SYS_PREFIX} -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
+        (
+          # exported list of "well known" build parameters
+          export APP_ABI SYS_PREFIX SYS_PATH SYS_ROOT SYS_ANDROIDAPI
+          veval "$SYS_GSC -:~~tgt=${SYS_PREFIX} -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
+        )
         if [ $veval_result != "0" ]; then rmifexists "$scm_ctgt"; fi
         assertfile "$scm_ctgt"
         rmifexists "$scm_otgt"

--- a/languages/scm.sh
+++ b/languages/scm.sh
@@ -131,7 +131,7 @@ compile_payload_scm()
 	# if [ $SYS_VERBOSE ]; then gsc_processing="$gsc_processing -expansion"; fi
         (
           # exported list of "well known" build parameters
-          export APP_ABI SYS_PREFIX SYS_PATH SYS_ROOT SYS_ANDROIDAPI
+          export SYS_PREFIX SYS_ROOT SYS_PATH SYS_ANDROIDAPI SYS_ANDROID_ABI
           veval "$SYS_GSC -:~~tgt=${SYS_PREFIX} -prelude \"$scm_opts\" -c -o $scm_ctgt $gsc_processing $scm_hdr $scm_src"
         )
         if [ $veval_result != "0" ]; then rmifexists "$scm_ctgt"; fi


### PR DESCRIPTION
This is the smallest change and most generic way I could come up with to tell the Scheme compiler more about the target environment.

Note that the `export`ed list might need to grow or being cut down.  Right now it's just a suggestion.  It will also require some care, as it is now "more-or-less-documented" once those build parameters where exported.

`SYS_ANDROIDAPI` looks right now like the minimum to make with #256 available on both older and newer versions.