### PR TITLE
MAKE.SH: handle module/plugin dependency loops

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -792,6 +792,11 @@ add_items_int()
     idir=`locatedir $itemname/$newi silent`
     if [ ! "X$idir" = "X" ]; then
       isold=no
+      for oldi in $lasti; do
+        if [ $oldi = $newi ]; then
+          isold=yes
+        fi
+      done
       for oldi in $items; do
         if [ $oldi = $newi ]; then
           isold=yes
@@ -808,10 +813,6 @@ add_items_int()
           lasti=`echo $lasti | cut -d' ' -f2-`
         else
           items="$items $newi"
-          newi=`echo $lasti | cut -d' ' -f1`
-          if [ ! "X$newi" = "X" ] && [ ! "X$oldi" = "X" ] && [ $oldi = $newi ]; then
-            lasti=`echo $lasti | cut -d' ' -f2-`
-          fi
         fi 
       fi
     else


### PR DESCRIPTION
This changes the way `add_items_int` handles loops in item dependencies (MODULES and PLUGINS).

Background:
Items are added recursively. Items are added to the list "items", and parent items are added to a stack, "lasti". Items that are already in the item list are skipped, since they have already been added.

Change:
Similarly, we can check if the current item is already in the "lasti" stack, and skip those as well. This allows for graceful handling of dependency loops (a parent item is encountered that is already in the parent stack).