### PR TITLE
CAMERA (Android): request permissions for API > 22 and allow for exte…

### DIFF
--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -106,6 +106,17 @@ public class @SYS_APPNAME@ extends Activity implements @ANDROID_JAVA_IMPLEMENTS@
     return true;
   }
 
+  @IF_ANDROIDAPI_GT_22@
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+      super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+      //Must do something with results data or app will hang
+      int rc = requestCode;
+      String p = permissions[0];
+      int gr = grantResults[0];
+  }
+  /* end of IF_ANDROIDAPI_GT_22 */
+
   @Override
   public void startActivityForResult(Intent intent, int cont) {
       try {

--- a/modules/camera/ANDROID_java_imports
+++ b/modules/camera/ANDROID_java_imports
@@ -1,6 +1,7 @@
 
 import android.provider.MediaStore;
 import android.os.Environment;
+import android.os.StrictMode;
 import java.io.File;
 
 import android.graphics.Bitmap;

--- a/modules/camera/ANDROID_java_oncreate
+++ b/modules/camera/ANDROID_java_oncreate
@@ -1,2 +1,3 @@
 checkOrRequestPermission(android.Manifest.permission.CAMERA);
-//checkOrRequestPermission(android.Manifest.permission.RECORD_AUDIO);
+StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
+StrictMode.setVmPolicy(builder.build());


### PR DESCRIPTION
…rnal storage URI

The Override function onRequestPermissionsResult is needed in bootstrap.java.in to prevent apps from hanging after asking permissions. A StrictMode.VmPolicy.Builder is needed in the camera module to get the URI of a file outside the app's storage, as per this thread: https://stackoverflow.com/questions/48117511/exposed-beyond-app-through-clipdata-item-geturi