### PR TITLE
DOWNLOAD fixes the extraction of download file size and status calculation

### DIFF
--- a/modules/download/download.scm
+++ b/modules/download/download.scm
@@ -238,10 +238,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;;returns percentage of filesize already downloaded; only works when destination file does not yet exist
 (define (download-status filepath)
-  (let ((tmpsize (if (file-exists? download:tempfile)  (file-size download:tempfile) 0.)))
+  (let ((tmpsize (if (file-exists? download:tempfile) (file-size download:tempfile) 0.)))
     (if (file-exists? filepath)
       1.
-      (if (> download:size 0) (/ (flo tmpsize)  download:size) 0.))
+      (if (> download:size 0) (/ (flo tmpsize) download:size) 0.))
   ))
 
 ;; eof

--- a/modules/download/download.scm
+++ b/modules/download/download.scm
@@ -111,7 +111,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                  (let* ((size-start (string-contains (car str) "Content-Length: "))
                         (size-rest (substring (car str) size-start (string-length (car str))))
                         (size-stop (string-contains size-rest "\n"))
-                        (size-only (string->number (substring size-rest 18 (- size-stop 1)))))
+                        (size-only (string->number (substring size-rest 16 (- size-stop 1)))))
                    (log-status "download:append: content length " size-only)
                    (set! download:size size-only)
                    (set! download:header 200)
@@ -238,10 +238,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;;returns percentage of filesize already downloaded; only works when destination file does not yet exist
 (define (download-status filepath)
-  (let ((tmpsize (if (file-exists? download:tempfile) (file-size download:tempfile) 0.)))
+  (let ((tmpsize (if (file-exists? download:tempfile)  (file-size download:tempfile) 0.)))
     (if (file-exists? filepath)
       1.
-      (if (> download:size 0) (/ tmpsize download:size) 0.))
+      (if (> download:size 0) (/ (flo tmpsize)  download:size) 0.))
   ))
 
 ;; eof


### PR DESCRIPTION
the two highest char of file size were not extracted. 
now force float division 