### PR TITLE
CAMERA(Android): use FileProvider to read and write data

### DIFF
--- a/apps/DemoCamera/ANDROID_xml_services
+++ b/apps/DemoCamera/ANDROID_xml_services
@@ -1,0 +1,11 @@
+ <provider
+    android:name="android.support.v4.content.FileProvider"
+    android:authorities="@SYS_PACKAGE_DOT@.provider"
+    android:exported="false"
+    android:grantUriPermissions="true">
+    <!-- resource file to create -->
+    <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths">  
+    </meta-data>
+</provider>

--- a/apps/DemoCamera/xml/file_paths.xml
+++ b/apps/DemoCamera/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <root-path name="root" path="." />
+</paths>

--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -106,6 +106,17 @@ public class @SYS_APPNAME@ extends Activity implements @ANDROID_JAVA_IMPLEMENTS@
     return true;
   }
 
+  @IF_ANDROIDAPI_GT_22@
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+      super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+      //Must do something with results data or app will hang
+      int rc = requestCode;
+      String p = permissions[0];
+      int gr = grantResults[0];
+  }
+  /* end of IF_ANDROIDAPI_GT_22 */
+
   @Override
   public void startActivityForResult(Intent intent, int cont) {
       try {

--- a/modules/camera/ANDROID_java_activityadditions
+++ b/modules/camera/ANDROID_java_activityadditions
@@ -14,7 +14,14 @@ private void startCamera(String fnl_name, String tmp_name) {
   Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
   File f = new File(camera_tmp);
   if (f != null) {
-    intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(f));
+    Uri imageUri = FileProvider.getUriForFile(this,
+            "@SYS_PACKAGE_DOT@.provider",
+            f);
+    intent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri);
+    if (@SYS_ANDROIDAPI@ <= 22) {
+      intent.setClipData(ClipData.newRawUri("", imageUri));
+      intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION|Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    }
 //    intent.putExtra(android.provider.MediaStore.EXTRA_SCREEN_ORIENTATION,ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     startActivityForResult(intent, REQUEST_IMAGE_CAPTURE);
   }
@@ -26,7 +33,14 @@ private void startVidCamera(String fnl_name, String tmp_name, int maxlength) {
   Intent intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
   File f = new File(vid_tmp);
   if (f != null) {
-    intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(f));
+    Uri vidUri = FileProvider.getUriForFile(this,
+            "@SYS_PACKAGE_DOT@.provider",
+            f);
+    intent.putExtra(MediaStore.EXTRA_OUTPUT, vidUri);
+    if (@SYS_ANDROIDAPI@ <= 22) {
+      intent.setClipData(ClipData.newRawUri("", vidUri));
+      intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION|Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    }
     if (maxlength > 0) {
       intent.putExtra(MediaStore.EXTRA_DURATION_LIMIT, maxlength);
     }

--- a/modules/camera/ANDROID_java_imports
+++ b/modules/camera/ANDROID_java_imports
@@ -10,4 +10,6 @@ import android.media.ExifInterface;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import android.support.v4.content.FileProvider;
+
 

--- a/modules/videoplayer/ANDROID_java_activityadditions
+++ b/modules/videoplayer/ANDROID_java_activityadditions
@@ -2,8 +2,12 @@
 private void startVideoPlayer(String mov_name, int orientation) {
   File f = new File(mov_name);
   if (f != null) { 
-    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.fromFile(f));
-    intent.setDataAndType(Uri.fromFile(f), "video/*");
+    Uri vidUri = FileProvider.getUriForFile(this,
+          "@SYS_PACKAGE_DOT@.provider",
+          f);
+    Intent intent = new Intent(Intent.ACTION_VIEW, vidUri);
+    intent.setDataAndType(vidUri, "video/*");
+    intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     if (orientation == 1) {
       orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
     } else if (orientation == 2) {

--- a/modules/videoplayer/ANDROID_java_imports
+++ b/modules/videoplayer/ANDROID_java_imports
@@ -1,3 +1,5 @@
 
 import java.io.File;
 
+import android.support.v4.content.FileProvider;
+

--- a/targets/android/build-binary
+++ b/targets/android/build-binary
@@ -144,8 +144,54 @@ else
 assert "### Gradle is not supported"
 fi
 
+# try to include support.v4 library
 if [ -f $ANDROIDSDK/extras/android/support/v4/android-support-v4.jar ]; then
   cp -r $ANDROIDSDK/extras/android/support/v4/android-support-v4.jar $tmpdir/libs
+  echo " => support-v4 library loaded"
+else
+  # look for support-v4 in alternate location
+  # special support for API 19
+  if [ $SYS_ANDROIDAPI -eq "19" ]; then
+    if [ -f $ANDROIDSDK/extras/android/m2repository/com/android/support/support-v4/19.1.0/support-v4-19.1.0.jar ]; then
+      cp -r $ANDROIDSDK/extras/android/m2repository/com/android/support/support-v4/19.1.0/support-v4-19.1.0.jar $tmpdir/libs
+      echo " => support-v4 library loaded (version 19)"
+    fi
+  else
+  # Find the directory containing the support-v4 AAR file
+  # Only folders from 20 - 23 have the full AAR file needed
+    supportv4version=$SYS_ANDROIDAPI
+    if [ $supportv4version -gt 23 ]; then
+      supportv4version="23"
+    fi
+    v4dir=""
+    while [ $supportv4version -gt "19" ]; do
+      v4dir=`find $ANDROIDSDK/extras/android/m2repository/com/android/support/support-v4 -name "$supportv4version*" | grep -v -e "alpha" -e "beta" | sort | tail -1`
+      if [ ! "X$v4dir" = "X" ]; then
+        break
+      fi
+      supportv4version=`expr ${supportv4version} - 1`
+    done
+    # If a directory is found, check if classes.jar has already been extracted. If not, extract it from the AAR
+    if [ ! "X$v4dir" = "X" ]; then
+      v4file=`find $v4dir -name classes.jar`
+      if [ ! -s "$v4file" ]; then
+        v4aar=`find $v4dir -name support-v4*.aar`
+        if [ -s "$v4aar" ]; then
+          unzip $v4aar classes.jar -d $v4dir > /dev/null
+          v4file=`find $v4dir -name classes.jar`
+        fi
+      fi
+      # If a classes.jar file has been found, copy it to libs
+      if [ -s "$v4file" ]; then
+        cp -r $v4file $tmpdir/libs
+        echo " => support-v4 library loaded (version $supportv4version)"
+      else
+        echo " => warning: support-v4 library not found"
+      fi
+    else
+      echo " => warning: support-v4 library not found"
+    fi
+  fi
 fi
 
 if [ "$NEED_GCM" = "yes" ]; then
@@ -185,7 +231,7 @@ if [ -d "$jarfilesdir" ]; then
   mkdir -p $tmpdir/libs/
   for jar in $jarfiles; do
     locajar=`basename $jar | tr A-Z a-z`
-    vecho " => coping jar file - $locajar ..."
+    vecho " => copying jar file - $locajar ..."
     cp $jar $tmpdir/libs/
   done
 fi
@@ -197,7 +243,7 @@ if [ -d "$xmlfilesdir" ]; then
   mkdir -p $tmpdir/res/xml/
   xmlfiles=`ls -1 $xmlfilesdir/*.xml 2> /dev/null`
   for xml in $xmlfiles; do
-    vecho " => coping xml file - $xml ..."
+    vecho " => copying xml file - $xml ..."
     cp $xml $tmpdir/res/xml/
   done
 fi


### PR DESCRIPTION
Updates build-binary to locate the support.v4 library for FileProvider. Uses FileProvider to properly obtain URIs and pass permissions for URI access. Addition of onRequestPermissionsResult to bootstrap.java.in to fix permission requests hanging. Apps that use FileProvider to pass URIs to activities must include ANDROID_xml_services and xml/file_paths.xml