### PR TITLE
ANDROID: do not call ReleaseStringUTFChars with an unrelated pointer

### DIFF
--- a/loaders/android/bootstrap.c.in
+++ b/loaders/android/bootstrap.c.in
@@ -66,11 +66,14 @@ static const char* app_directory_files = NULL;
 static const char* app_code_path = NULL;
 
 void Java_@SYS_PACKAGE_UNDERSCORE@_@SYS_APPNAME@_nativeInstanceInit(JNIEnv* env, jobject thiz, jstring codePath, jstring directoryFiles){
+  const char* tmp;
   globalObj = (*env)->NewGlobalRef(env,thiz);
-  app_directory_files = strdup((*env)->GetStringUTFChars(env, directoryFiles, 0));
-  (*env)->ReleaseStringUTFChars(env, directoryFiles, app_directory_files);
-  app_code_path = strdup((*env)->GetStringUTFChars(env, codePath, 0));
-  (*env)->ReleaseStringUTFChars(env, codePath, app_code_path);
+  tmp = (*env)->GetStringUTFChars(env, directoryFiles, 0);
+  app_directory_files = strdup(tmp);
+  (*env)->ReleaseStringUTFChars(env, directoryFiles, tmp);
+  tmp = (*env)->GetStringUTFChars(env, codePath, 0);
+  app_code_path = strdup(tmp);
+  (*env)->ReleaseStringUTFChars(env, codePath, tmp);
 }
 
 char* android_getFilesDir() {


### PR DESCRIPTION
Fixes the issue in

https://github.com/part-cw/lambdanative/commit/7561c9a28036d5d7b92c4078fdd3ea1f924992d7#commitcomment-44425578
