### PR TITLE
ANDROID: allow superclass to see touch events

### DIFF
--- a/loaders/android/bootstrap.java.in
+++ b/loaders/android/bootstrap.java.in
@@ -259,6 +259,7 @@ class  xGLSurfaceView extends GLSurfaceView {
     setRenderer(renderer);
   }
   public boolean onTouchEvent(final MotionEvent event) {
+    super.onTouchEvent(event);
     t=0;
     x=(int)event.getX(); y=(int)event.getY();
     switch (event.getAction()&MotionEvent.ACTION_MASK) {


### PR DESCRIPTION
As there are complaints about touch/backbutton not doing the expected thing, I recalled that I fixed something related some time ago.  It is required by webview and may help elsewhere.