### PR TITLE
CORE: remove unused-in-ln, deprecated predicate list-notempty?

### DIFF
--- a/modules/ln_core/list.scm
+++ b/modules/ln_core/list.scm
@@ -37,9 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 |#
 ;; list related extras
 
-;; Check for empty lists - this one is better than using pair? for it!
-(define (list-notempty? lst) (and (list? lst) (not (null? lst))))
-
 ;; Make a list of length n, where each element is set to elem
 (define (make-list n #!optional (elem 0))
   (if (zero? n) '()


### PR DESCRIPTION
This appears to be not used anywhere.  If it is used elsewhere, it is
better replaced!  Complexity class: O(n)

Suggested replacements:

1. `pair?` - test head only

2. in case of doubt wrt. input: once `list?` to test object being a
propper list and `pair?` once the former succeeded.