### PR TITLE
REDCAP: fix parsing of xml from list. make check that value is string

### DIFF
--- a/modules/redcap/redcap.scm
+++ b/modules/redcap/redcap.scm
@@ -148,7 +148,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                        (fieldname (if (string? field) field (symbol->string field)))
                        (values    (cdr lpair))
                        (itemize   (lambda (v)
-                                    (let ((value (if (number? v) (number->string v) v)))
+                                    (let ((value (if (number? v) (number->string v) (if (string? v) v "NA"))))
                                       (string-append
                                         "<item>"
                                         "<record>" record "</record>"


### PR DESCRIPTION
`(redcap:list->xmlstr ... )` crashed when in the list a non-string was (like '#f') 
This adds an extra check and replaces non-strings with "NA" to prevent unecessary crashes 