### PR TITLE
[FIX] [WSL2] cross-compilation on WSL2 for windows requires special build config

### DIFF
--- a/libraries/libdmtx/make.sh
+++ b/libraries/libdmtx/make.sh
@@ -13,6 +13,12 @@ if [ ! $SYS_PLATFORM = $SYS_HOSTPLATFORM ]; then
   EXTRACONF=--host=$SYS_ARCH
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF --disable-shared --enable-static
 
 package_make

--- a/libraries/libfcgi/make.sh
+++ b/libraries/libfcgi/make.sh
@@ -7,6 +7,12 @@ if [ ! "$SYS_PLATFORM" = "$SYS_HOSTPLATFORM" ]; then
   EXTRACONF=--host=`echo "${SYS_ARCH}-" | cut -f 1 -d "-"`
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 # the shipping config.guess is out of date, fix that
 cp $SYS_ROOT/config.guess .
 package_configure $EXTRACONF --disable-shared --enable-static

--- a/libraries/libfreetype/make.sh
+++ b/libraries/libfreetype/make.sh
@@ -9,7 +9,16 @@ if [ ! $SYS_PLATFORM = $SYS_HOSTPLATFORM ]; then
   EXTRACONF=--host=$SYS_ARCH
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
+
 package_configure $EXTRACONF --enable-static --disable-shared --without-png --without-harfbuzz --without-zlib --without-bzip2 --enable-freetype-config
+
+
 
 package_make
 package_make install

--- a/libraries/libgd/make.sh
+++ b/libraries/libgd/make.sh
@@ -17,6 +17,12 @@ cp src/gd.h tmp
 cat tmp | sed 's/^#define BGD_DECLARE(rt) BGD_EXPORT_DATA_PROT rt BGD_STDCALL/#define BGD_DECLARE(rt) rt/g' > src/gd.h
 rm tmp
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF --disable-shared --enable-static --with-png=$SYS_PREFIX --with-freetype=$SYS_PREFIX --with-jpeg=$SYS_PREFIX --without-tiff --without-xpm --without-fontconfig --without-x
 
 cd src

--- a/libraries/libopus/make.sh
+++ b/libraries/libopus/make.sh
@@ -29,6 +29,12 @@ if [ "$SYS_PLATFORM" = "$SYS_HOSTPLATFORM" ]; then
   EXTRACONF=
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF  --enable-static --disable-shared
 
 mv Makefile tmp

--- a/libraries/libportaudio/make.sh
+++ b/libraries/libportaudio/make.sh
@@ -39,6 +39,12 @@ if [ $SYS_HOSTPLATFORM = openbsd ]; then
   EXTRACONF="--without-alsa --without-oss"
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF --enable-static --disable-shared --without-jack
 
 mv Makefile tmp

--- a/libraries/libuuid/make.sh
+++ b/libraries/libuuid/make.sh
@@ -11,12 +11,18 @@ if [ ! $SYS_PLATFORM = $SYS_HOSTPLATFORM ]; then
   EXTRACONF=--host=$SYS_ARCH
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF --enable-static --disable-shared
 package_make
 package_make install
 
 # move the headers to prevent potential clash with system headers
-if [ -d $SYS_PREFIX/include/uuid ]; then 
+if [ -d $SYS_PREFIX/include/uuid ]; then
   mv $SYS_PREFIX/include/uuid $SYS_PREFIX/include/ln_uuid
 fi
 

--- a/libraries/libzip/make.sh
+++ b/libraries/libzip/make.sh
@@ -9,6 +9,12 @@ if [ ! $SYS_PLATFORM = $SYS_HOSTPLATFORM ]; then
   EXTRACONF=--host=$SYS_ARCH
 fi
 
+if [ "$SYS_PLATFORM" = "win32" ]; then
+  if grep microsoft /proc/version -i -q; then
+    EXTRACONF="$EXTRACONF --build=x86_64-unknown-linux-gnu"
+  fi
+fi
+
 package_configure $EXTRACONF --enable-static --disable-shared
 
 package_patch

--- a/modules/httpsclient/httpsclient.scm
+++ b/modules/httpsclient/httpsclient.scm
@@ -66,7 +66,7 @@ static int check_chain=0;
 static char chainfile[256];
 
 #ifdef WIN32
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #define bzero(a, b) memset(a, 0x0, b)
 #define bcopy(a, b, c) memmove(b, a, c)
 #endif


### PR DESCRIPTION
enables cross compilation on WSL2 for win32. addresses issue #430 
tested on all Demo* apps and a few private ones.

Currently fails on LNHealth because of libuuid with 
```
randutils.c:17:10: fatal error: sys/syscall.h: No such file or directory
   17 | #include <sys/syscall.h>
      |          ^~~~~~~~~~~~~~~
```