### PR TITLE
M1/M2 (apple silicon) macosx support

### DIFF
--- a/configure
+++ b/configure
@@ -127,7 +127,7 @@ case "$hostsys" in
 *-linux-gnu*)
   SYS_HOSTPLATFORM="linux"
 ;;
-x86_64-apple-darwin*)
+*-apple-darwin*)
   SYS_HOSTPLATFORM="macosx"
 ;;
 *-openbsd*)


### PR DESCRIPTION
Little patch to support m1/m2 (apple silicon) Macs.

I testest with DemoSchemeAndC (needs brew install autoconf) and Calculator (need brew install imagemagick)